### PR TITLE
add template_success and template_failure to notifications

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -724,6 +724,11 @@ Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repo
 
 **Expected format:** List of strings; or a single string.
 
+#### `notifications.campfire.template_error`
+Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
+
+**Expected format:** List of strings; or a single string.
+
 #### `notifications.campfire.template_failure`
 Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
 
@@ -825,6 +830,11 @@ Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repo
 
 **Expected format:** List of strings; or a single string.
 
+#### `notifications.hipchat.template_error`
+Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
+
+**Expected format:** List of strings; or a single string.
+
 #### `notifications.hipchat.template_failure`
 Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
 
@@ -882,6 +892,11 @@ Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repo
 
 **Expected format:** List of strings; or a single string.
 
+#### `notifications.irc.template_error`
+Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
+
+**Expected format:** List of strings; or a single string.
+
 #### `notifications.irc.template_failure`
 Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
 
@@ -927,6 +942,11 @@ Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repo
 
 **Expected format:** List of strings; or a single string.
 
+#### `notifications.slack.template_error`
+Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
+
+**Expected format:** List of strings; or a single string.
+
 #### `notifications.slack.template_failure`
 Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
 
@@ -965,6 +985,11 @@ Value has to be `always`, `never` or `change`. Setting is case sensitive.
 **Expected format:** List of strings or encrypted strings; or a single string or encrypted string.
 
 #### `notifications.sqwiggle.template`
+Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
+
+**Expected format:** List of strings; or a single string.
+
+#### `notifications.sqwiggle.template_error`
 Strings will be interpolated. Available variables: `%{repository_slug}`, `%{repository_name}`, `%{repository}`, `%{build_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{message}`, `%{duration}`, `%{compare_url}`, `%{build_url}`.
 
 **Expected format:** List of strings; or a single string.

--- a/lib/travis/yaml/nodes/notifications.rb
+++ b/lib/travis/yaml/nodes/notifications.rb
@@ -50,7 +50,7 @@ module Travis::Yaml
       end
 
       class WithTemplate < Notification
-        map :template, :template_success, :template_failure, to: Template
+        map :template, :template_success, :template_failure, :template_error, to: Template
       end
 
       class IRC < WithTemplate


### PR DESCRIPTION
See travis-ci/travis-ci#1332. Before merging check that it corresponds with the final implementation of travis-ci/travis-core#368.
