### PR TITLE
(feature) add iojs support

### DIFF
--- a/lib/travis/yaml/nodes/root.rb
+++ b/lib/travis/yaml/nodes/root.rb
@@ -9,7 +9,7 @@ module Travis::Yaml
       map :deploy, :ruby, :os, :compiler, :git, :jdk, :virtualenv, :matrix, :env, :notifications, :branches, :cache, :addons, :android
       map :lein, :otp_release, :go, :ghc, :xcode_sdk, :xcode_scheme, :perl, :php, :python, :services, :gemfile, :dart, to: VersionList
       map :podfile, to: Version
-      map :node_js, to: VersionList[/^\d+\.\d+(\.\d+)?$/]
+      map :node_js, to: VersionList[/^((iojs)|(iojs\-v\d+\.\d+(\.\d+)?)|(\d+\.\d+(\.\d+)?))$/]
       map :rvm, to: :ruby
       map :otp, to: :otp_release
       map :node, to: :node_js

--- a/spec/nodes/node_js_spec.rb
+++ b/spec/nodes/node_js_spec.rb
@@ -1,14 +1,20 @@
 describe Travis::Yaml do
   context 'from ruby' do
     specify 'valid versions' do
-      config = Travis::Yaml.parse(node_js: ['0.10', '0.8.0'], language: 'node.js')
-      expect(config.node_js).to be == ['0.10', '0.8.0']
+      config = Travis::Yaml.parse(node_js: ['0.10', '0.8.0', 'iojs', 'iojs-v1.0', 'iojs-v1.0.0'], language: 'node.js')
+      expect(config.node_js).to be == ['0.10', '0.8.0', 'iojs', 'iojs-v1.0', 'iojs-v1.0.0']
     end
 
     specify 'invalid versions' do
       config = Travis::Yaml.parse(node_js: ['0.10.x', '0.8.0'], language: 'node.js')
       expect(config.node_js).to be == ['0.8.0']
       expect(config.nested_warnings).to include([['node_js'], 'value "0.10.x" is not a valid version'])
+
+      iojs_config = Travis::Yaml.parse(node_js: ['iojs', 'iojs-v', 'iojs-v1.x', 'iojs-v1.0.x'], language: 'node.js')
+      expect(iojs_config.node_js).to be == ['iojs']
+      expect(iojs_config.nested_warnings).to include([['node_js'], 'value "iojs-v" is not a valid version'])
+      expect(iojs_config.nested_warnings).to include([['node_js'], 'value "iojs-v1.x" is not a valid version'])
+      expect(iojs_config.nested_warnings).to include([['node_js'], 'value "iojs-v1.0.x" is not a valid version'])
     end
   end
 end


### PR DESCRIPTION
__Issue__:
`travis-yaml` supports numeric versions for `node.js`, but not the `iojs` versions as specified in the [javascript with node-js documentation](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/) and the [build environment update history](http://docs.travis-ci.com/user/build-environment-updates/2015-02-03/#Node.js-VM).

![iojs_fail](https://cloud.githubusercontent.com/assets/2647488/6667014/6ec51be4-cba6-11e4-95d3-db25f4880134.gif)

__This PR__:
Addresses #54 by adding `iojs` support within [travis-yaml/lib/travis/yaml/nodes/root.rb](https://github.com/francismakes/travis-yaml/blob/issue-54-iojs-support/lib/travis/yaml/nodes/root.rb#L12) and an [updated specification](https://github.com/francismakes/travis-yaml/blob/03bf4c5b4457b5af355d44a6261f20cae6317eb0/spec/nodes/node_js_spec.rb#L13-L17).

I welcome a code review for both the regular expression and the assertions made against it. Thanks in advance!