### PR TITLE
Add C# support to fix #61

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -401,7 +401,7 @@ List of `jdk` versions to use.
 #### `language`
 **This setting is required!**
 
-Value has to be `c`, `cpp`, `clojure`, `d`, `dart`, `erlang`, `go`, `groovy`, `haskell`, `haxe`, `java`, `node_js`, `objective-c`, `ruby` (default), `python`, `perl`, `php`, `scala`, `android`, `crystal` or `generic`; or one of the known aliases: `dartlang` for `dart`, `jvm` for `java`, `javascript` for `node_js`, `node` for `node_js`, `nodejs` for `node_js`, `golang` for `go`, `objective_c` for `objective-c`, `obj_c` for `objective-c`, `objc` for `objective-c`, `c++` for `cpp`, `node.js` for `node_js`, `obj-c` for `objective-c`, `bash` for `generic`, `sh` for `generic` or `shell` for `generic`. Setting is not case sensitive.
+Value has to be `c`, `cpp`, `clojure`, `csharp`, `d`, `dart`, `erlang`, `go`, `groovy`, `haskell`, `haxe`, `java`, `node_js`, `objective-c`, `ruby` (default), `python`, `perl`, `php`, `scala`, `android`, `crystal` or `generic`; or one of the known aliases: `dartlang` for `dart`, `jvm` for `java`, `javascript` for `node_js`, `node` for `node_js`, `nodejs` for `node_js`, `golang` for `go`, `objective_c` for `objective-c`, `obj_c` for `objective-c`, `objc` for `objective-c`, `c++` for `cpp`, `node.js` for `node_js`, `obj-c` for `objective-c`, `bash` for `generic`, `sh` for `generic` or `shell` for `generic`. Setting is not case sensitive.
 
 **Expected format:** String.
 
@@ -1225,6 +1225,13 @@ Commands that will be run on the VM.
 List of `services` versions to use.
 
 **Expected format:** List of strings; or a single string.
+
+#### `solution`
+**This setting is only relevant if [`language`](#language) is set to `csharp`.**
+
+The C# solution to build.
+
+**Expected format:** String.
 
 #### `source_key`
 **Expected format:** String or encrypted string.

--- a/lib/travis/yaml/nodes/language.rb
+++ b/lib/travis/yaml/nodes/language.rb
@@ -6,7 +6,7 @@ module Travis::Yaml
 
       value :c, :cpp, :clojure, :d, :dart, :erlang, :go, :groovy, :haskell, :haxe, :java,
             :node_js, :"objective-c", :ruby, :rust, :python, :perl, :php, :scala,
-            :android, :crystal
+            :android, :crystal, :csharp
       value dartlang: :dart, jvm: :java, javascript: :node_js, node: :node_js,
             nodejs: :node_js, golang: :go, objective_c: :"objective-c",
             obj_c: :"objective-c", objc: :"objective-c"

--- a/lib/travis/yaml/nodes/language_specific.rb
+++ b/lib/travis/yaml/nodes/language_specific.rb
@@ -30,7 +30,8 @@ module Travis::Yaml
         npm_args:         %w[node_js],
         android:          %w[android],
         d:                %w[d],
-        crystal:          %w[crystal]
+        crystal:          %w[crystal],
+        solution:         %w[csharp]
       }
 
       def verify_language(language)


### PR DESCRIPTION
Adds support for the ```csharp``` language and the csharp-specific ```solution``` value to the YAML parser to resolve #61.

I used previous commits to add other languages as a guide to add this in, so let me know if anything additional needs adding that I've missed.