### PR TITLE
Add pushover support.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1018,6 +1018,41 @@ Strings will be interpolated. Available variables: `%{repository}`, `%{repositor
 #### `notifications.irc.use_notice`
 **Expected format:** Boolean value.
 
+#### `notifications.pushover`
+**Expected format:** Key value mapping, or list of strings or encrypted strings, or boolean value.
+
+#### `notifications.pushover.api_key`
+**Expected format:** String or encrypted string.
+
+#### `notifications.pushover.disabled`
+**Expected format:** Boolean value.
+
+#### `notifications.pushover.enabled`
+**Expected format:** Boolean value.
+
+#### `notifications.pushover.on_failure`
+Value has to be `always`, `never` or `change`. Setting is case sensitive.
+
+**Expected format:** String.
+
+#### `notifications.pushover.on_start`
+Value has to be `always`, `never` or `change`. Setting is case sensitive.
+
+**Expected format:** String.
+
+#### `notifications.pushover.on_success`
+Value has to be `always`, `never` or `change`. Setting is case sensitive.
+
+**Expected format:** String.
+
+#### `notifications.pushover.template`
+Strings will be interpolated. Available variables: `%{repository}`, `%{repository_slug}`, `%{repository_name}`, `%{build_number}`, `%{build_id}`, `%{pull_request}`, `%{pull_request_number}`, `%{branch}`, `%{commit}`, `%{author}`, `%{commit_subject}`, `%{commit_message}`, `%{result}`, `%{duration}`, `%{message}`, `%{compare_url}`, `%{build_url}`, `%{pull_request_url}`.
+
+**Expected format:** List of strings; or a single string.
+
+#### `notifications.pushover.users`
+**Expected format:** List of strings or encrypted strings; or a single string or encrypted string.
+
 #### `notifications.slack`
 **Expected format:** Key value mapping, or list of strings or encrypted strings, or boolean value.
 

--- a/lib/travis/yaml/nodes/notifications.rb
+++ b/lib/travis/yaml/nodes/notifications.rb
@@ -78,6 +78,11 @@ module Travis::Yaml
         map :use_notice, :skip_join, to: Scalar[:bool]
       end
 
+      class Pushover < WithTemplate
+        list :users
+        map :api_key, to: Scalar[:str, :secure]
+      end
+
       class Hipchat < WithTemplate
         map :format, to: FixedValue[:html, :text]
         list :rooms
@@ -94,6 +99,7 @@ module Travis::Yaml
       map :flowdock,                    to: Flowdock
       map :hipchat,                     to: Hipchat
       map :irc,                         to: IRC
+      map :pushover,                    to: Pushover
       map :webhook,                     to: :webhooks
     end
   end

--- a/spec/nodes/notifications_spec.rb
+++ b/spec/nodes/notifications_spec.rb
@@ -49,4 +49,12 @@ describe Travis::Yaml::Nodes::Notifications do
       expect(config.notifications.flowdock.api_token).to be == "foo"
     end
   end
+
+  context :pushover do
+    example "handles basic setup" do
+      config = Travis::Yaml.parse(notifications: { pushover: { api_key: "foo", users: ["bar"] } })
+      expect(config.notifications.pushover.api_key).to be == "foo"
+      expect(config.notifications.pushover.users).to be == ["bar"]
+    end
+  end
 end


### PR DESCRIPTION
Pushover settings are currently dropped by `travis-yaml`

This adds support. I am a complete noob when it comes to Ruby (I was googling "what is a Rakefile"), so don't be surprised if this sucks. I won't be offended if somebody closes this and redoes it. I just want pushover notifications supported.

I've got it as two separate commits (the actual implementation, and the update to Spec.md). If you would prefer that squished, or that I drop the second (Spec.md) commit, I am happy to oblige.
