### PR TITLE
Add new values to 'cache' validator

### DIFF
--- a/lib/travis/yaml/nodes/cache.rb
+++ b/lib/travis/yaml/nodes/cache.rb
@@ -1,7 +1,7 @@
 module Travis::Yaml
   module Nodes
     class Cache < Mapping
-      map :apt, :bundler, :cocoapods, to: Scalar[:bool]
+      map :apt, :bundler, :cocoapods, :pip, :ccache, to: Scalar[:bool]
       map :edge, to: Scalar[:bool], experimental: true
       map :directories, to: Sequence
 
@@ -11,6 +11,8 @@ module Travis::Yaml
           visit_key_value(visitor, :bundler,   value)
           visit_key_value(visitor, :apt,       value)
           visit_key_value(visitor, :cocoapods, value)
+          visit_key_value(visitor, :pip, value)
+          visit_key_value(visitor, :ccache, value)
         when :str
           key = visitor.generate_key(self, value)
           self[key] = true

--- a/spec/nodes/cache_spec.rb
+++ b/spec/nodes/cache_spec.rb
@@ -2,12 +2,12 @@ describe Travis::Yaml::Nodes::Cache do
   context 'from Ruby' do
     specify 'with true' do
       config = Travis::Yaml.parse(cache: true)
-      expect(config.cache).to be == { 'apt' => true, 'bundler' => true, 'cocoapods' => true }
+      expect(config.cache).to be == { 'apt' => true, 'bundler' => true, 'cocoapods' => true, 'pip' => true, 'ccache' => true }
     end
 
     specify 'with false' do
       config = Travis::Yaml.parse(cache: false)
-      expect(config.cache).to be == { 'apt' => false, 'bundler' => false, 'cocoapods' => false }
+      expect(config.cache).to be == { 'apt' => false, 'bundler' => false, 'cocoapods' => false, 'pip' => false, 'ccache' => false }
     end
 
     specify 'with string' do
@@ -29,12 +29,12 @@ describe Travis::Yaml::Nodes::Cache do
   context 'from YAML' do
     specify 'with true' do
       config = Travis::Yaml.parse('cache: on')
-      expect(config.cache).to be == { 'apt' => true, 'bundler' => true, 'cocoapods' => true }
+      expect(config.cache).to be == { 'apt' => true, 'bundler' => true, 'cocoapods' => true, 'pip' => true, 'ccache' => true }
     end
 
     specify 'with false' do
       config = Travis::Yaml.parse('cache: off')
-      expect(config.cache).to be == { 'apt' => false, 'bundler' => false, 'cocoapods' => false }
+      expect(config.cache).to be == { 'apt' => false, 'bundler' => false, 'cocoapods' => false, 'pip' => false, 'ccache' => false }
     end
 
     specify 'with string' do


### PR DESCRIPTION
**pip** and **ccache** was added as possible values for `cache` node (according to [documentation](https://docs.travis-ci.com/user/caching/))