### PR TITLE
Remove feature warning for using 'dist: trusty'

### DIFF
--- a/lib/travis/yaml/nodes/root.rb
+++ b/lib/travis/yaml/nodes/root.rb
@@ -23,7 +23,7 @@ module Travis::Yaml
       map :dist, to: Dist
       map :group, to: Group
 
-      FEATURE_KEYS = [:dist, :group]
+      FEATURE_KEYS = [:group]
 
       def initialize
         super(nil)

--- a/spec/nodes/dist_spec.rb
+++ b/spec/nodes/dist_spec.rb
@@ -1,7 +1,6 @@
 describe Travis::Yaml::Nodes::Dist do
-  it 'adds warnings about feature' do
-    expect(Travis::Yaml.parse(language: 'ruby', dist: 'precise').warnings).
-      to include('your repository must be feature flagged for the "dist" setting to be used')
+  specify 'has no warnings' do
+    expect(Travis::Yaml.parse(language: 'ruby', dist: 'precise').warnings).to be_empty
   end
 
   specify 'set dist value' do


### PR DESCRIPTION
All repositories can now use `dist: trusty`, without the need to be flagged for the feature:
https://blog.travis-ci.com/2015-10-14-opening-up-ubuntu-trusty-beta/

Fixes #79.