### PR TITLE
JWT addon support

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -103,6 +103,9 @@ Note that stricitly speaking Travis CI might not have the same understanding of 
 #### `addons.sauce_connect.username`
 **Expected format:** String or encrypted string.
 
+#### `addons.jwt`
+**Expected format:** List of secured strings; or a single secured string.
+
 #### `addons.ssh_known_hosts`
 **Expected format:** List of strings; or a single string.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -104,7 +104,7 @@ Note that stricitly speaking Travis CI might not have the same understanding of 
 **Expected format:** String or encrypted string.
 
 #### `addons.jwt`
-**Expected format:** List of secured strings; or a single secured string.
+**Expected format:** List of strings; or encrypted strings.
 
 #### `addons.ssh_known_hosts`
 **Expected format:** List of strings; or a single string.

--- a/lib/travis/yaml/nodes/addons.rb
+++ b/lib/travis/yaml/nodes/addons.rb
@@ -40,6 +40,7 @@ module Travis::Yaml
       map :sauce_connect,   to: Addon[:username, :access_key], drop_empty: false
       map :ssh_known_hosts, to: Sequence
       map :apt_packages,    to: Sequence
+      map :jwt,             to: Sequence
     end
   end
 end

--- a/lib/travis/yaml/nodes/addons.rb
+++ b/lib/travis/yaml/nodes/addons.rb
@@ -40,7 +40,7 @@ module Travis::Yaml
       map :sauce_connect,   to: Addon[:username, :access_key], drop_empty: false
       map :ssh_known_hosts, to: Sequence
       map :apt_packages,    to: Sequence
-      map :jwt,             to: Sequence
+      map :jwt,             to: Sequence[:secure]
     end
   end
 end

--- a/spec/nodes/addons_spec.rb
+++ b/spec/nodes/addons_spec.rb
@@ -66,7 +66,25 @@ describe Travis::Yaml::Nodes::Addons do
     end
 
     context 'jwt' do
-      example { expect(addons(jwt: [ "String" ]).jwt).to be == ["String"] }
+      example do
+        # uses parse directly instead of addons() so secure works
+        config = Travis::Yaml.parse <<-YAML.gsub(/^ {10}/, '')
+          ---
+          language: ruby
+          addons:
+            jwt:
+            - secure: "SECURE_STRING"
+            - secure: "SECURE_STRING_2"
+        YAML
+        expect(config.addons.jwt.length).to be == 2
+
+        string = ""
+        config.addons.jwt[0].decrypt { |s| string = s }
+        expect(string).to be == "SECURE_STRING"
+
+        config.addons.jwt[1].decrypt { |s| string = s }
+        expect(string).to be == "SECURE_STRING_2"
+      end
     end
   end
 end

--- a/spec/nodes/addons_spec.rb
+++ b/spec/nodes/addons_spec.rb
@@ -64,5 +64,9 @@ describe Travis::Yaml::Nodes::Addons do
       example { expect(addons(apt_packages: 'curl').apt_packages).to be == ['curl'] }
       example { expect(addons(apt_packages: ['curl', 'git']).apt_packages).to be == ['curl', 'git'] }
     end
+
+    context 'jwt' do
+      example { expect(addons(jwt: [ "String" ]).jwt).to be == ["String"] }
+    end
   end
 end


### PR DESCRIPTION
I noticed during my tests `travis lint` doesn't work 'cause its not defined yet.

```
Warnings for .travis.yml:
[x] value for addons section is empty, dropping
[x] in addons section: unexpected key jwt, droppin
```

Kinda a placeholder till I get a PR ready

@BanzaiMan 

Hopefully this is okay
