### PR TITLE
Support on_pull_requests for hipchat and slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
 - 2.1.2
 
 sudo: false
+before_install: gem update bundler
 script: bundle exec rspec
 bundler_args: "--without play"

--- a/SPEC.md
+++ b/SPEC.md
@@ -1010,6 +1010,9 @@ Value has to be `always`, `never` or `change`. Setting is case sensitive.
 
 **Expected format:** String.
 
+#### `notifications.hipchat.on_pull_requests`
+**Expected format:** Boolean value.
+
 #### `notifications.hipchat.on_start`
 Value has to be `always`, `never` or `change`. Setting is case sensitive.
 
@@ -1126,6 +1129,9 @@ Strings will be interpolated. Available variables: `%{repository}`, `%{repositor
 Value has to be `always`, `never` or `change`. Setting is case sensitive.
 
 **Expected format:** String.
+
+#### `notifications.slack.on_pull_requests`
+**Expected format:** Boolean value.
 
 #### `notifications.slack.on_start`
 Value has to be `always`, `never` or `change`. Setting is case sensitive.

--- a/lib/travis/yaml/nodes/notifications.rb
+++ b/lib/travis/yaml/nodes/notifications.rb
@@ -72,6 +72,15 @@ module Travis::Yaml
         map :template, to: Template
       end
 
+      class WithPullRequestSwitch < WithTemplate
+        map :on_pull_requests, to: Scalar[:bool]
+      end
+
+      class Hipchat < WithPullRequestSwitch
+        list :rooms
+        map :format, to: FixedValue[:html, :text]
+      end
+
       class IRC < WithTemplate
         list :channels
         map :channel_key, :password, :nickserv_password, :nick, to: Scalar[:str, :secure]
@@ -83,11 +92,6 @@ module Travis::Yaml
         map :api_key, to: Scalar[:str, :secure]
       end
 
-      class Hipchat < WithTemplate
-        map :format, to: FixedValue[:html, :text]
-        list :rooms
-      end
-
       class Flowdock < Notification
         map :api_token, to: Scalar[:str, :secure]
         prefix_scalar :api_token, :str, :secure
@@ -95,7 +99,8 @@ module Travis::Yaml
 
       map :webhooks,                    to: Notification[:urls]
       map :email,                       to: Notification[:recipients]
-      map :sqwiggle, :slack, :campfire, to: WithTemplate[:rooms]
+      map :sqwiggle, :campfire,         to: WithTemplate[:rooms]
+      map :slack,                       to: WithPullRequestSwitch[:rooms]
       map :flowdock,                    to: Flowdock
       map :hipchat,                     to: Hipchat
       map :irc,                         to: IRC

--- a/spec/nodes/notifications_spec.rb
+++ b/spec/nodes/notifications_spec.rb
@@ -57,4 +57,18 @@ describe Travis::Yaml::Nodes::Notifications do
       expect(config.notifications.pushover.users).to be == ["bar"]
     end
   end
+
+  context :slack do
+    example "handles pull-request flag" do
+      config = Travis::Yaml.parse(notifications: { slack: { on_pull_requests: true } })
+      expect(config.notifications.slack.on_pull_requests).to be
+    end
+  end
+
+  context :hipchat do
+    example "handles pull-request flag" do
+      config = Travis::Yaml.parse(notifications: { hipchat: { on_pull_requests: true } })
+      expect(config.notifications.hipchat.on_pull_requests).to be
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for the `on_pull_requests` flag documented here: https://docs.travis-ci.com/user/notifications/#Notifications-of-PR-builds

I don't have much experience in ruby and wasn't sure if / how to add a test but to my understanding, there aren't tests for any property right?

Related issue: #121.